### PR TITLE
Implement --PBAB option + refactor sale filtering in one place.

### DIFF
--- a/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
+++ b/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
@@ -28,7 +28,6 @@ export type T_OpenSeaSale = {
     saleType: "Single" | "Bundle";
     blockNumber: number;
     blockTimestamp: string;
-    summarayTokenSold: string;
     seller: string;
     buyer: string;
     paymentToken: string;


### PR DESCRIPTION
Removed the split in sales filtering (pre-filter and filter when processing the report).
The filter now happens in one place and directly removes the non interesting sales before processing them and generating the `ProjectReport`s.

The --PBAB flag is also added and is doing the opposite of the --flagship flag.