### PR TITLE
Merge + Add OpenSeaV1/OpenSeaV2 filter

### DIFF
--- a/RoyaltiesProcessorDelivery/src/index.ts
+++ b/RoyaltiesProcessorDelivery/src/index.ts
@@ -93,13 +93,15 @@ async function processSales(
       }
 
       const openSeaFilterPass = openSeaFilter === undefined || openSeaSale.openSeaVersion === openSeaFilter;
+      console.log(openSeaFilter);
+      console.log(openSeaSale.openSeaVersion);
       if (openSeaFilterPass === false) {
         skippedOpenSeaVersion += 1;
         return false;
       }
 
       const token = openSeaSaleLookupTable.token;
-      const curationFilterPass = collectionFilter === undefined || token.project.curationStatus !== collectionFilter;
+      const curationFilterPass = collectionFilter === undefined || token.project.curationStatus === collectionFilter;
       if (curationFilterPass === false) {
         skippedCurationStatus += 1;
         return false;
@@ -225,7 +227,7 @@ yargs(hideBin(process.argv))
             "Only the sales between the given block numbers ([startingBlock; endingBlock[) will be processed. If no endingBlock is provided it will run up to the current block number",
           type: "number",
         })
-        .option("os-version", {
+        .option("osVersion", {
           description: "A filter to only process sales of OpenSea V1 or OpenSea V2",
           type: "string",
           choices: ["V1", "V2"],
@@ -272,7 +274,7 @@ yargs(hideBin(process.argv))
       let writeToCsv = argv.csv !== undefined;
       let outputPath = argv.outputPath as string | undefined;
 
-      const openSeaVersion = argv.collection as OpenSeaVersion | undefined;
+      const openSeaVersion = argv.osVersion as OpenSeaVersion | undefined;
       let salesFilter: SalesFilter = {
         openSeaFilter: openSeaVersion,
       }

--- a/RoyaltiesProcessorDelivery/src/services/report_service.ts
+++ b/RoyaltiesProcessorDelivery/src/services/report_service.ts
@@ -215,9 +215,7 @@ export class ReportService {
     } = projectReport;
     const escapedProjectName = name.replace(sep, "");
 
-    let projectReportData = `${escapedProjectName}${sep}${totalSales}${sep}${artistAddress}${sep}${
-      additionalPayeeAddress === undefined ? "None" : additionalPayeeAddress
-    }`;
+    let projectReportData = `${escapedProjectName}${sep}${totalSales}${sep}${artistAddress}${sep}${additionalPayeeAddress === undefined ? "None" : additionalPayeeAddress}`;
 
     // Loop for all possible payment token listed by Art Blocks
     for (const crypto of ART_BLOCKS_PAYMENT_TOKENS) {

--- a/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
+++ b/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
@@ -25,6 +25,7 @@ type T_OpenSeaSaleLookupTable = {
 
 export type T_OpenSeaSale = {
     id: string;
+    openSeaVersion: "V1" | "V2";
     saleType: "Single" | "Bundle";
     blockNumber: number;
     blockTimestamp: string;

--- a/RoyaltiesProcessorDelivery/src/types/project_report.ts
+++ b/RoyaltiesProcessorDelivery/src/types/project_report.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from "ethers";
-import { BLOCK_WHERE_PRIVATE_SALES_HAVE_ROYALTIES } from "../constant";
-import { addressToPaymentToken, ETH_ADDR, WETH_ADDR } from "../utils/token_conversion";
-import { T_OpenSeaSale } from "./graphQL_entities_def";
+import { addressToPaymentToken } from "../utils/token_conversion";
+
 
 export type CryptoRepartition = {
     toArtist: BigNumber,


### PR DESCRIPTION
Allow to pass another option parameter to the `range ` command: `--osVersion V1` or `--osVersion V2`. When specified only OpenSea sales happening on the targeted contract are processed. If absent, all sales are processed.

Left to implement: add the OpenSea version in the CSV data.

PS: Will not work before the subgraph is also updated and fully synced.