### PR TITLE
Fix bundle sale logic when using subgraph

### DIFF
--- a/ArtistAssistant/readme.md
+++ b/ArtistAssistant/readme.md
@@ -73,6 +73,8 @@ The inspect command lets you inspect all the sales made on OpenSea for a given p
 # Assumptions
 **IMPORTANT FOR ALL USERS TO BE AWARE OF THESE - CURRENT SET OF ASSUMPTIONS ARE INVALID FOR SOME EDGE-CASE OPENSEA SALES**
 
+*This script's logic is behind the state of Royalties Processor Delivery, and could handle edge-cases better if updated*
+
 Until properly handled, these assumptions may result in incorrect royalty estimates.
 
 - Assumes all artists always have a 5% royalty

--- a/RoyaltiesProcessorDelivery/.env.example
+++ b/RoyaltiesProcessorDelivery/.env.example
@@ -1,1 +1,1 @@
-OPENSEA_API_KEY=<only required if using OpenSea API mode>
+OPENSEA_API_KEY=

--- a/RoyaltiesProcessorDelivery/readme.md
+++ b/RoyaltiesProcessorDelivery/readme.md
@@ -18,6 +18,8 @@ At the project root run the following commands:
 yarn install
 ````
 
+You will also need to create a `.env` file at this directory's root populated with an OpenSea API key (see `.env.example` for format). The API key is always required because royalty collection logic for bundle sales on OpenSea's platform depends on each token's OpenSea collection slug, which is defined off-chain and can therefore not be included in the Art Blocks subgraph.
+
 ## Basic Usage Overview & Example
 
 This tool should be ran from a command line interface.

--- a/RoyaltiesProcessorDelivery/src/services/opensea_sales_service.ts
+++ b/RoyaltiesProcessorDelivery/src/services/opensea_sales_service.ts
@@ -201,34 +201,10 @@ export class OpenSeaSalesService {
           tokenZero: _tokenZero,
         });
       } else {
-        try {
-          collectionSlug = await getOpenSeaAssetCollectionSlug(
-            _tokenZero.tokens[0].contract.id,
-            _tokenZero.tokens[0].tokenId.toString()
-          );
-        } catch (error) {
-          // likely too many requests, cool off for ten seconds
-          console.warn(
-            "[WARNING] likely too many requests... cooling down for 20 seconds"
-          );
-          await delay(15000);
-          // OS API appears to make us fail once more before working
-          try {
-            await getOpenSeaAssetCollectionSlug(
-              _tokenZero.tokens[0].contract.id,
-              _tokenZero.tokens[0].tokenId.toString()
-            );
-          } catch {
-            console.log("[INFO] failed once more as expected");
-          }
-          await delay(5000);
-          console.info("[INFO] resuming");
-          collectionSlug = await getOpenSeaAssetCollectionSlug(
-            _tokenZero.tokens[0].contract.id,
-            _tokenZero.tokens[0].tokenId.toString()
-          );
-          console.debug("[INFO] successfully recovered");
-        }
+        collectionSlug = await getOpenSeaAssetCollectionSlug(
+          _tokenZero.tokens[0].contract.id,
+          _tokenZero.tokens[0].tokenId.toString()
+        );
         slugsAndTokenZeros.push({
           collectionSlug: collectionSlug,
           tokenZero: _tokenZero,
@@ -239,8 +215,6 @@ export class OpenSeaSalesService {
           collectionSlug
         );
         collectionSlugCache.save(true);
-        // Throttle due to OpenSea API rate limiting
-        await delay(500);
       }
     }
     // OS api works in terms of timestamps, not blocks.


### PR DESCRIPTION
### Please merge #11 and update this base branch to main before merging 🙏 

This update filters out OpenSea bundle sales in Royalty Processor Delivery when tokens in a bundle sale are from more than a single OpenSea collection. 

This aligns the subgraph logic with observed OpenSea behavior. It also makes subgraph results the same as OpenSea API-based results, except for transactions when our subgraph loses data on transactions with multiple Atomic Match calls in a single transaction. That is a known bug that must be fixed in our subgraph before these scripts can be updated.

Adds caveat to Artist Assistant readme because that script is not updated to handle some recent updates to Royalty Processor Delivery. Recommend updating Artist Assistant codebase once subgraph is updated.