### PR TITLE
Handle pbab projects on core

### DIFF
--- a/RoyaltiesProcessorDelivery/config/pbabProjectsOnFlagship.json
+++ b/RoyaltiesProcessorDelivery/config/pbabProjectsOnFlagship.json
@@ -1,0 +1,10 @@
+{
+  "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270-95": {
+    "pbab_contract": "0xbdde08bd57e5c9fd563ee7ac61618cb2ecdc0ce0",
+    "comments": "OpenSea CryptoVenetian royalties paid to Crypto Citizens PBAB"
+  },
+  "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270-189": {
+    "pbab_contract": "0xbdde08bd57e5c9fd563ee7ac61618cb2ecdc0ce0",
+    "comments": "OpenSea CryptoNewYorker royalties paid to Crypto Citizens PBAB"
+  }
+}

--- a/RoyaltiesProcessorDelivery/src/repositories/token_zero_repository.ts
+++ b/RoyaltiesProcessorDelivery/src/repositories/token_zero_repository.ts
@@ -3,19 +3,13 @@ import { gql } from "graphql-request";
 import { GraphQLDatasource } from "../datasources/graphQL_datasource";
 import { T_TokenZero } from "../types/graphQL_entities_def";
 
-const QUERY_GET_FLAGSHIP_TOKEN_ZEROS = gql`
+const QUERY_GET_TOKEN_ZEROS = gql`
   query getTokenZeros($first: Int!, $skip: Int!) {
     projects(
       first: $first
       skip: $skip
       orderBy: projectId
-      where: {
-        invocations_not: 0
-        contract_in: [
-          "0x059edd72cd353df5106d2b9cc5ab83a52287ac3a"
-          "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270"
-        ]
-      }
+      where: WHERE_CLAUSE
     ) {
       id
       curationStatus
@@ -50,10 +44,36 @@ export class TokenZeroRepository {
     this.#graphQLDatasource = graphQLDatasource;
   }
 
-  async getAllTokenZeros(
-    variables: T_QueryVariable_GetTokenZeros
+  /**
+   * This returns *all* T_TokenZero objects for all contracts in
+   * contracts parameter (limited by first/skip parameters in variables)
+   */
+  async getAllTokenZerosOnContracts(
+    variables: T_QueryVariable_GetTokenZeros,
+    contracts: string[]
   ): Promise<T_TokenZero[]> {
-    const query = QUERY_GET_FLAGSHIP_TOKEN_ZEROS;
+    const contractsQuery = contracts.map((_contractId) => `"${_contractId}"`);
+    const query = QUERY_GET_TOKEN_ZEROS.replace(
+      "WHERE_CLAUSE",
+      `{ invocations_not: 0, contract_in: [${contractsQuery}] }`
+    );
+    const resp = await this.#graphQLDatasource.query(query, variables);
+    return resp.projects as T_TokenZero[];
+  }
+
+  /**
+   * This returns *all* T_TokenZero objects for all projectIds in
+   * projectIds parameter (limited by first/skip parameters in variables)
+   */
+  async getAllTokenZerosWithProjectIds(
+    variables: T_QueryVariable_GetTokenZeros,
+    projectIds: string[]
+  ): Promise<T_TokenZero[]> {
+    const projectIdsQuery = projectIds.map((_projectId) => `"${_projectId}"`);
+    const query = QUERY_GET_TOKEN_ZEROS.replace(
+      "WHERE_CLAUSE",
+      `{ invocations_not: 0, id_in: [${projectIdsQuery}] }`
+    );
     const resp = await this.#graphQLDatasource.query(query, variables);
     return resp.projects as T_TokenZero[];
   }

--- a/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
+++ b/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
@@ -40,7 +40,7 @@ export type T_OpenSeaSale = {
 };
 
 export type T_TokenZero = {
-  id: string;
+  id: string; // subgraph's Project entity id for this TokenZero
   curationStatus: string;
   tokens: T_Token[];
 };

--- a/RoyaltiesProcessorDelivery/src/types/project_report.ts
+++ b/RoyaltiesProcessorDelivery/src/types/project_report.ts
@@ -50,11 +50,7 @@ export class ProjectReport {
     addSale(openSeaSale: T_OpenSeaSale, nbTokensSold: number) {
       this.#totalSales += 1;
 
-      // The price is divided between the number of tokens in the sale
-      //      : The subgraph only register AB tokens in for Bundle. If the bundle contains other NFTs
-      //!       royalties aren't collected anyway, so they (TODO: will) already filtered out before here.
-      //!       But this edges case is extremely rare
-      //!       (This is noted as an assumption in readme)
+      // The price is divided equally between the number of tokens in the sale
       const priceAttributedToProject = BigNumber.from(openSeaSale.price).div(
         nbTokensSold
       );

--- a/RoyaltiesProcessorDelivery/src/utils/util_functions.ts
+++ b/RoyaltiesProcessorDelivery/src/utils/util_functions.ts
@@ -1,3 +1,19 @@
 export function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export function arraysEqual(a, b) {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length !== b.length) return false;
+
+  for (var i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+// find any common elements in two arrays
+export function findCommonElements(arr1: any[], arr2: any[]) {
+  return arr1.some((item) => arr2.includes(item));
+}

--- a/RoyaltiesProcessorDelivery/tsconfig.json
+++ b/RoyaltiesProcessorDelivery/tsconfig.json
@@ -57,6 +57,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     /* Advanced Options */
     "skipLibCheck": true, /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true,                /* Allow importing json files */
   }
 }


### PR DESCRIPTION
Please merge #12  and update this base branch to main before merging 🙏

This adds a config file (and logic to consume the config file) to generically define PBAB project on AB flagship core contracts.

The behavior can be summarized as:
- PBAB projects on flagship core contracts are excluded from reports when the --flagship flag is used 
- PBAB projects on flagship core are included in reports when the --contract <PBAB_core_contract_address> command is used

An example would be:
- CryptoCitizens projects CryptoVenetians and CryptoNewYorkers are not included when the `--flagship` flag is used
- ...but they *are* included when the `--contract 0xbdde08bd57e5c9fd563ee7ac61618cb2ecdc0ce0` command is used (even though the projects are on our core contract)
