### PR TITLE
OpenSea API mode bug fix

### DIFF
--- a/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
+++ b/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
@@ -285,7 +285,12 @@ export async function getOpenSeaSalesEvents(
       // only include if new sale's block is >= minBlock
       if (newOpenSeaSales[i].blockNumber >= minBlockNumber) {
         openSeaSales.push(newOpenSeaSales[i]);
+      } else if (newOpenSeaSales[i].blockNumber === null) {
+        // have observed OS API return this for failed transactions
+        // sale did not occur (even though a successful event), so just skip
+        console.debug(`[DEBUG] Skipped failed tx with null block number on collection ${collectionSlug}`)
       } else {
+        // valid block number less than min block number, break out of scrolling
         _reachedMinBlockNumber = true;
       }
     }


### PR DESCRIPTION
### Please merge #15 and update this base to main prior to merging this pr 🙏

OpenSea's api has been observed returning `successful` sale events with a null block_number.

This updates our script to handle that case appropriately by skipping the tx (null block_number appears to mean the tx actually reverted) instead of unintentionally breaking out of our loop looking for more sales.

For reference, here is a sale tx that is recorded as a successful event on OpenSea's api, but with a null block_number: https://etherscan.io/tx/0x94a4fe0af510fc5537aa31b33ab40fff5eed101f5b0594620fe4a7b5e12fa8f3