### PR TITLE
handle buggy os api events with null payment token

### DIFF
--- a/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
+++ b/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
@@ -199,13 +199,19 @@ function openSeaEventModelToSubgraphModel(
     // complete conversion to subgraph T_OpenSeaSale model
     try {
       if (_event.payment_token === null) {
-        console.warn("payment token is NULL from OpenSea's api. " + 
-        "This has been observed at least once, and assumption that payment " +
-        "token was ETH was valid. Assuming ETH is payment token, but " +
-        "recommend validating on etherscan.")
-        console.warn(`The relavent tx for msg above is: ${_event.transaction.transaction_hash}`)
+        console.warn(
+          "[WARN] Payment token is NULL from OpenSea's api. " +
+            "This has been observed at least once, and assumption that payment " +
+            "token was ETH was valid. Assuming ETH is payment token, but " +
+            "recommend validating on etherscan."
+        );
+        console.warn(
+          `[WARN] The relavent tx for msg above is: ${_event.transaction.transaction_hash}`
+        );
         // assign payment token to ETH
-        _event.payment_token = {"address": "0x0000000000000000000000000000000000000000"};
+        _event.payment_token = {
+          address: "0x0000000000000000000000000000000000000000",
+        };
       }
     const _sale: T_OpenSeaSale = {
       id: _event.id,
@@ -223,6 +229,7 @@ function openSeaEventModelToSubgraphModel(
     };
     return _sale;
   } catch (e) {
+    console.error("[ERROR] Error in OpenSeaSaleConverter");
     console.error(_event)
     console.error(_event.payment_token)
     throw(e)

--- a/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
+++ b/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
@@ -197,6 +197,16 @@ function openSeaEventModelToSubgraphModel(
      */
 
     // complete conversion to subgraph T_OpenSeaSale model
+    try {
+      if (_event.payment_token === null) {
+        console.warn("payment token is NULL from OpenSea's api. " + 
+        "This has been observed at least once, and assumption that payment " +
+        "token was ETH was valid. Assuming ETH is payment token, but " +
+        "recommend validating on etherscan.")
+        console.warn(`The relavent tx for msg above is: ${_event.transaction.transaction_hash}`)
+        // assign payment token to ETH
+        _event.payment_token = {"address": "0x0000000000000000000000000000000000000000"};
+      }
     const _sale: T_OpenSeaSale = {
       id: _event.id,
       openSeaVersion: "Vunknown",
@@ -212,6 +222,11 @@ function openSeaEventModelToSubgraphModel(
       openSeaSaleLookupTables: _openSeaLookupTables,
     };
     return _sale;
+  } catch (e) {
+    console.error(_event)
+    console.error(_event.payment_token)
+    throw(e)
+  }
   });
 }
 


### PR DESCRIPTION
this was a new os api event response issue that began happening in May 2022. Roughly 20 or so OS sales list payment token as `null` instead of `ETH` or `WETH`.

This fix assumes payment token was `ETH`, and logs a warning telling the user that a null payment token was encountered, that ETH was assumed to be the payment token, and logs the tx hash of the tx containing the sale.

Because OS API is a centralized third-party API, there isn't much we can do other than handle, assume, and warn when an invalid `null` payment token is encountered.