### PR TITLE
Add Seaport capability to OS API mode

### DIFF
--- a/RoyaltiesProcessorDelivery/readme.md
+++ b/RoyaltiesProcessorDelivery/readme.md
@@ -74,9 +74,15 @@ This command processes and summarizes all supported exchanges (currently OpenSea
 - `--csv`: boolean, output results to csv
 - `--outputPath`: set if override of default output path is desired
 - `--osAPI`: gathers sales events from OpenSea's API instead of the subgraph. This relies on OpenSea to have categorized tokens in appropriate collections, collections haven't changed between time of sale and time of query, trusts the data in OpenSea's database, etc. Note that subgraph is still used to enumerate projects on core contract. Also note that project slugs are cached by default, and may be invalidated by deleting the `./slug_cache` directory (clearing cache only required if OpenSea changes a project's collection slug).
-  > Note: Using OpenSea API mode only works with `--flagship` or `--contract`. Also `--exchange` must to be set to "OS".
+  > Note: Using OpenSea API mode only works with `--flagship` or `--contract`. Also `--exchange` must to be set to either `"OS_Wyvern"`, `"OS_Seaport"`, or `"OS_All"`.
 - `--pbabInvoice`: generates a PBAB invoice detailed report, assuming 2.5% royalties to render provider. Must be filtered down to a single contract via `--contract` command.
-- `--exchange`: Specify the exchange to process the sales from. Supported exchanges are : "OS_V1" for OpenSea Wyvern V1, "OS_V2" for OpenSea Wyvern V2, "OS" for OpenSea Wyvern V1 and V2 or "LR_V1" for Looksrare.
+- `--exchange`: Specify the exchange to process the sales from. Supported exchanges are : 
+  - "OS_V1" for OpenSea Wyvern V1
+  - "OS_V2" for OpenSea Wyvern V2
+  - "OS_Wyvern" for OpenSea Wyvern V1 and V2
+  - "OS_Seaport" for OpenSea Seaport
+  - "OS_All" for OpenSea Wyvern V1, V2, and Seaport
+  - "LR_V1" for Looksrare.
 
 A common example of a query running this command is:
 
@@ -122,6 +128,9 @@ Until properly handled, these assumptions may result in incorrect payment estima
 - _no known bugs at this time_
 
 > When using OpenSea API mode, there are no known bugs at this time. If you discover a new previously unknown bug when using OpenSea API mode, please file a bug in this project's public GitHub repository: https://github.com/ArtBlocks/artblocks-community-tooling/issues
+
+**Potentially Change in Future**:
+> When using OpenSea API mode, we assume when `only_opensea` is false, the only sales returned are from the Wyvern V1 and V2 contracts **AND** the Seaport contracts. This assumption has confirmed to be correct by OpenSea as of July 2022, but there is no promise that this will not change in the future. If this assumption is incorrect, we will need to update the script to filter sales from any additional contracts. Ideally, we depreciate osAPI mode and use subgraph mode instead, in the future.
 
 # Dependencies
 

--- a/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
+++ b/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
@@ -244,12 +244,13 @@ export async function getOpenSeaSalesEvents(
   collectionSlug: string,
   tokenZero: T_TokenZero,
   occurredBeforeTimestamp: number,
-  minBlockNumber: number
+  minBlockNumber: number,
+  only_opensea: boolean
 ): Promise<T_Sale[]> {
   const openSeaSales: T_Sale[] = []
   let _next = ''
   while (true) {
-    let url = `https://api.opensea.io/api/v1/events?only_opensea=true&collection_slug=${collectionSlug}&event_type=successful&occurred_before=${occurredBeforeTimestamp}`
+    let url = `https://api.opensea.io/api/v1/events?only_opensea=${only_opensea}&collection_slug=${collectionSlug}&event_type=successful&occurred_before=${occurredBeforeTimestamp}`
     if (_next !== '') {
       url = url + `&cursor=${_next}`
     }

--- a/RoyaltiesProcessorDelivery/src/types/filters.ts
+++ b/RoyaltiesProcessorDelivery/src/types/filters.ts
@@ -1,0 +1,16 @@
+export type Exchange =
+  | 'OS_V1'
+  | 'OS_V2'
+  | 'OS_Wyvern'
+  | 'OS_Seaport'
+  | 'OS_All'
+  | 'LR_V1'
+
+export type Collection = 'curated' | 'playground' | 'factory'
+
+export type SalesFilter = {
+  collectionFilter?: Collection
+  contractFilterType?: 'ONLY' | 'ONLY_NOT'
+  contractsFilter?: string[]
+  exchangeFilter?: Exchange
+}

--- a/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
+++ b/RoyaltiesProcessorDelivery/src/types/graphQL_entities_def.ts
@@ -26,7 +26,7 @@ export type T_SaleLookupTable = {
 
 export type T_Sale = {
   id: string
-  exchange: 'OS_V1' | 'OS_V2' | 'LR_V1' | 'OS_Vunknown'
+  exchange: 'OS_V1' | 'OS_V2' | 'OS_SP' | 'LR_V1' | 'OS_Vunknown'
   saleType: 'Single' | 'Bundle'
   blockNumber: number
   blockTimestamp: string


### PR DESCRIPTION
## Change Summary
This allows us to query either OS_Wyvern, OS_Seaport, or OS_All when using OS API mode. These buckets must be understood when auditing royalty payments received from OpenSea that are to be forwarded to artists.

## New Assumptions
It relies on the logic of the OpenSea API not including Seaport sales when `only_opensea` is set to true, and OpenSea API return Seaport and Wyvern sales when `only_opensea` is set to false. Currently, OpenSea has confirmed that is the behavior of their API, but there are no promises that will remain the case forever. Thus, we need to audit/sanity check results when using OpenSea API mode when attempting to include Seaport sales in any reports.

## Regression Testing
I've ensured this update does not affect results queried for Wyvern in June 2022. Additionally, sanity checks comparing against results generated from subgraph make sense (the current fully-synced subgraph has some minor incorrect assumptions, but only applies to a few rare edge-cases).