### PR TITLE
add debug mode to royalties processor delivery

### DIFF
--- a/RoyaltiesProcessorDelivery/src/index.ts
+++ b/RoyaltiesProcessorDelivery/src/index.ts
@@ -111,7 +111,8 @@ async function processSales(
   salesFilter: SalesFilter,
   useOpenSeaApi: boolean,
   pbabInvoice: boolean,
-  csvOutputFilePath?: string
+  csvOutputFilePath?: string,
+  debug?: boolean
 ) {
   // apply special cases based on desired filter
   /** Handle excluded projectIds by filtering them out later in this function
@@ -199,7 +200,7 @@ async function processSales(
         ) {
           filteredSales.push(_sales)
         } else {
-          console.log(
+          console.info(
             `[INFO] Skipped bundle sale because multiple OS collection slugs (expect no royalties collected): ${_sales.id}`
           )
           bundleSalesWithMultipleCollectionSlugs++
@@ -376,6 +377,16 @@ async function processSales(
       Array.from(projectReports.values()),
       csvRawOutputFilePath
     )
+    if (debug) {
+      const debugOutputFilePath = csvOutputFilePath.replace(
+        '.csv',
+        '_DEBUG_ALL_SALE_IDS.csv'
+      )
+      reportService.generateDebugCSVFromProjectReports(
+        sales,
+        debugOutputFilePath
+      )
+    }
     return
   }
   // Print output to console
@@ -461,6 +472,11 @@ yargs(hideBin(process.argv))
             'LR_V1',
           ],
         })
+        .option('DEBUG', {
+          description:
+            'If present, a csv file will be output containing all sale IDs for the generated csv reports',
+          type: 'boolean',
+        })
     },
     async (argv) => {
       let startingBlock = argv.startingBlock as number
@@ -471,6 +487,10 @@ yargs(hideBin(process.argv))
 
       let useOpenSeaApi = argv.osAPI as boolean | false
       console.info('[INFO] Use OpenSea API Mode? -> ', !!useOpenSeaApi)
+      let debug = argv.DEBUG as boolean | false
+      if (debug) {
+        console.info('[INFO] Debug Mode Enabled')
+      }
 
       const collection = argv.collection as Collection | undefined
       const exchange = argv.exchange as Exchange | undefined
@@ -549,7 +569,8 @@ yargs(hideBin(process.argv))
         salesFilter,
         !!useOpenSeaApi,
         !!pbabInvoice,
-        outputPath
+        outputPath,
+        debug
       )
     }
   )

--- a/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
+++ b/RoyaltiesProcessorDelivery/src/repositories/opensea_api.ts
@@ -214,7 +214,9 @@ function openSeaEventModelToSubgraphModel(
         }
       }
       const _sale: T_Sale = {
-        id: _event.id,
+        // id is slightly different than subgraph schema because we can't know index of
+        // this token sale for a tx that contains many separate purchases
+        id: `${_event.transaction.transaction_hash}-${_event.id}`,
         exchange: 'OS_Vunknown',
         saleType: _saleType,
         blockNumber: _event.transaction.block_number,

--- a/RoyaltiesProcessorDelivery/src/services/report_service.ts
+++ b/RoyaltiesProcessorDelivery/src/services/report_service.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'ethers'
 import { writeFileSync } from 'fs'
 
+import { T_Sale } from '../types/graphQL_entities_def'
 import { ProjectReport } from '../types/project_report'
 import {
   amountHumanReadable,
@@ -347,6 +348,22 @@ export class ReportService {
       csvData += formatedReportData
     }
     console.log(`Raw results written to ${csvOutputFilePath}`)
+    writeFileSync(csvOutputFilePath, csvData)
+  }
+
+  generateDebugCSVFromProjectReports(
+    sales: T_Sale[],
+    csvOutputFilePath: string
+  ): void {
+    const sep = this.#csvSeparator
+
+    let projectReportHeader = `DEBUG - ALL SALE IDS`
+    let csvData = projectReportHeader + '\n'
+
+    for (const sale of sales) {
+      csvData += `${sale.id}\n`
+    }
+    console.log(`DEBUG results written to ${csvOutputFilePath}`)
     writeFileSync(csvOutputFilePath, csvData)
   }
 


### PR DESCRIPTION
>Please merge only after #25 

## Change Summary
This simply adds a debug mode where devs can output a csv file that includes all `Sale` entity IDs included in output totals. This is very useful when troubleshooting any issues/concerns when auditing output reports.